### PR TITLE
pixiv: Use more accurate login error messages

### DIFF
--- a/passrotate/providers/pixiv.py
+++ b/passrotate/providers/pixiv.py
@@ -30,7 +30,7 @@ class Pixiv(Provider):
             "password": old_password
         })
         r = self._session.post("https://accounts.pixiv.net/api/login",
-                data=self._form)
+                params={"lang": "en"}, data=self._form)
         json = r.json()
         if "body" in json and \
            "validation_errors" in json['body']:
@@ -38,6 +38,8 @@ class Pixiv(Provider):
                 raise Exception("Pixiv has locked us out of further login attempts. Try again later.")
             elif json['body']['validation_errors'].get("captcha"):
                 raise Exception("Failed to log into pixiv: captcha authentication required")
+            else:
+                raise Exception("Failed to log into pixiv: {}".format(json['body']['validation_errors']))
 
         r = self._session.get("https://www.pixiv.net/setting_userdata.php",
                 params={"type": "password"})

--- a/passrotate/providers/pixiv.py
+++ b/passrotate/providers/pixiv.py
@@ -35,7 +35,7 @@ class Pixiv(Provider):
                 params={"type": "password"})
         url = urlparse(r.url)
         if url.path != "/setting_userdata.php":
-            raise Exception("Current password for pixiv is incorrect")
+            raise Exception("Failed to log into pixiv with current password")
         self._form = get_form(r.text, action="setting_userdata.php")
         self._form.update({
             "check_pass": old_password


### PR DESCRIPTION
Looks like pixiv sometimes requires solving a captcha to log in. No requests are performed before a captcha box appears (and it only appears after clicking "login"), so detecting it doesn't seem like a simple task.