### PR TITLE
Problem: Cant use pass-rotate when $ACCOUNT is not in the root of pass

### DIFF
--- a/pass-rotate
+++ b/pass-rotate
@@ -106,16 +106,17 @@ for account in args.get("<accounts>"):
     cfg = config[account]
     domain = cfg.get("domain") or account
     provider = pass_rotate.get_provider(domain, dict(cfg))
+    pass_name = cfg["pass-name"] if "pass-name" in cfg else account
     if not provider:
         print("Error: pass-rotate does not have a service provider for {}".format(domain))
         errs += 1
         continue
-    sys.stderr.write("Rotating {}... ".format(account))
+    sys.stderr.write("Rotating {}... ".format(pass_name))
     sys.stderr.flush()
     try:
-        old_password = get_password(account)
+        old_password = get_password(pass_name)
         provider.prepare(old_password)
-        new_password = gen_password(account)
+        new_password = gen_password(pass_name)
         provider.execute(old_password, new_password)
         sys.stderr.write("OK\n")
     except:


### PR DESCRIPTION
My layout of pass is: `Internet/<domain>/<email>` so `pass-rotate github.com` will obviously not find my entry.. I added an option to override the used entry to the ini file. It's called `pass-name` so my github config now looks like:

```
[github.com]
username=myuser
pass-name=Internet/github.com/mymail
```
