### PR TITLE
WIP: Problem: There are not specific exceptions

### DIFF
--- a/pass-rotate
+++ b/pass-rotate
@@ -124,8 +124,8 @@ for account in args.get("<accounts>"):
             provider.prepare(old_password)
         except PrepareException as e:
             sys.stderr.write("FAIL\n")
-            sys.stderr.write("Preparation failed: {}\n".format(e.args))
-            sys.stderr.write("Your password is unchanged, skipping...")
+            sys.stderr.write("Preparation failed: \"{}\"\n".format(e.args[0]))
+            sys.stderr.write("Your password stays unchanged, skipping {}...".format(account))
             sys.stderr.flush()
             errs +=1
             continue
@@ -136,7 +136,7 @@ for account in args.get("<accounts>"):
             provider.execute(old_password, new_password)
         except ExecuteException as e:
             sys.stderr.write("FAIL\n")
-            sys.stderr.write("Execution failed: {}\n".format(e.args))
+            sys.stderr.write("Execution failed: \"{}\"\n".format(e.args[0]))
             sys.stderr.write("Reverting the updated password in your password-store... ")
             sys.stderr.flush()
 

--- a/pass-rotate
+++ b/pass-rotate
@@ -23,6 +23,8 @@ import sys
 import os
 from getpass import getpass
 
+from passrotate.exceptions import PrepareException, ExecuteException
+
 args = docopt(__doc__, version='pass-rotate 1.0')
 
 pass_rotate = PassRotate()
@@ -113,11 +115,38 @@ for account in args.get("<accounts>"):
         continue
     sys.stderr.write("Rotating {}... ".format(pass_name))
     sys.stderr.flush()
+
+    # we keep the global exception catching to catch other errors as well
     try:
         old_password = get_password(pass_name)
-        provider.prepare(old_password)
-        new_password = gen_password(pass_name)
-        provider.execute(old_password, new_password)
+
+        try:
+            provider.prepare(old_password)
+        except PrepareException as e:
+            sys.stderr.write("FAIL\n")
+            sys.stderr.write("Preparation failed: {}\n".format(e.args))
+            sys.stderr.write("Your password is unchanged, skipping...")
+            sys.stderr.flush()
+            errs +=1
+            continue
+
+
+        try:
+            new_password = gen_password(pass_name)
+            provider.execute(old_password, new_password)
+        except ExecuteException as e:
+            sys.stderr.write("FAIL\n")
+            sys.stderr.write("Execution failed: {}\n".format(e.args))
+            sys.stderr.write("Reverting the updated password in your password-store... ")
+            sys.stderr.flush()
+
+            # todo: revert password here
+
+            sys.stderr.write("done\n")
+            sys.stderr.flush()
+            errs +=1
+            continue
+
         sys.stderr.write("OK\n")
     except:
         sys.stderr.write("FAIL\n")

--- a/passrotate/exceptions.py
+++ b/passrotate/exceptions.py
@@ -1,0 +1,11 @@
+
+class PassRotateException(Exception):
+    pass
+
+
+class PrepareException(PassRotateException):
+    pass
+
+
+class ExecuteException(Exception):
+    pass

--- a/passrotate/providers/ankiweb.py
+++ b/passrotate/providers/ankiweb.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form
 import requests
@@ -30,7 +31,7 @@ class AnkiWeb(Provider):
         r = self._session.post("https://ankiweb.net/account/login",
                                data=self._form, allow_redirects=False)
         if not r.ok or r.status_code != 302:
-            raise Exception("Unable to log into AnkiWeb with current password")
+            raise PrepareException("Unable to log into AnkiWeb with current password")
         r = self._session.get("https://ankiweb.net/account/settings")
         self._form = get_form(r.text)
 
@@ -43,7 +44,7 @@ class AnkiWeb(Provider):
         r = self._session.post("https://ankiweb.net/account/settings",
                                data=self._form, allow_redirects=False)
         if not r.ok or r.status_code != 302:
-            raise Exception("Failed to update AnkiWeb password")
+            raise ExecuteException("Failed to update AnkiWeb password")
 
 
 register_provider(AnkiWeb)

--- a/passrotate/providers/cloudflare.py
+++ b/passrotate/providers/cloudflare.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form
 from urllib.parse import urlparse
@@ -39,7 +40,7 @@ class Cloudflare(Provider):
         r = self._session.post("https://www.cloudflare.com/a/login", data=form)
         url = urlparse(r.url)
         if url.path != "/a/overview":
-            raise Exception("Failed to log into Cloudflare with current password")
+            raise PrepareException("Failed to log into Cloudflare with current password")
         r = self._session.get("https://www.cloudflare.com/a/account/my-account")
         bs = get_bootstrap(r.text)
         self._atok = bs["atok"]
@@ -53,6 +54,6 @@ class Cloudflare(Provider):
             "x-atok": self._atok
         })
         if r.status_code != 200:
-            raise Exception("Failed to update Cloudflare password")
+            raise ExecuteException("Failed to update Cloudflare password")
 
 register_provider(Cloudflare)

--- a/passrotate/providers/digitalocean.py
+++ b/passrotate/providers/digitalocean.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form
 from bs4 import BeautifulSoup
@@ -32,7 +33,7 @@ class DigitalOcean(Provider):
         r = self._session.post("https://cloud.digitalocean.com/sessions", data=form)
         url = urlparse(r.url)
         if url.path != "/droplets":
-            raise Exception("Unable to log into Digital Ocean with current password")
+            raise PrepareException("Unable to log into Digital Ocean with current password")
         soup = BeautifulSoup(r.text, "html.parser")
         for script in soup.find_all("script"):
             text = script.text.strip()
@@ -60,6 +61,6 @@ class DigitalOcean(Provider):
                     "X-CSRF-Token": self._csrf_token
                 })
         if r.status_code != 200:
-            raise Exception("Failed to update Digital Ocean password")
+            raise ExecuteException("Failed to update Digital Ocean password")
 
 register_provider(DigitalOcean)

--- a/passrotate/providers/discord.py
+++ b/passrotate/providers/discord.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, PromptType, register_provider
 import requests
 
@@ -28,7 +29,7 @@ class Discord(Provider):
                 json=data)
 
         if r.status_code != 200:
-            raise Exception("Unable to log into Discord with your current password: {}".format(r.json()))
+            raise PrepareException("Unable to log into Discord with your current password: {}".format(r.json()))
 
         json = r.json()
         if json.get("mfa"):
@@ -61,7 +62,7 @@ class Discord(Provider):
                     code = self.prompt("Enter your two factor (TOTP) code", PromptType.totp)
                     data["code"] = code
                 else:
-                    raise Exception("Failed to update Discord password: {}".format(json))
+                    raise ExecuteException("Failed to update Discord password: {}".format(json))
             else:
                 break
 

--- a/passrotate/providers/facebook.py
+++ b/passrotate/providers/facebook.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form
 import requests
@@ -32,9 +33,9 @@ class Facebook(Provider):
 
         ###check for authentication failure
         if "The email address that you&#039;ve entered doesn&#039;t match any account" in r.text:
-            raise Exception("Facebook doesn't recognise this email")
+            raise PrepareException("Facebook doesn't recognise this email")
         if "The password you entered is incorrect" in r.text:
-            raise Exception("Incorrect password")
+            raise PrepareException("Incorrect password")
 
         ###load form
         r = self._session.get("https://m.facebook.com/settings/security/password/")

--- a/passrotate/providers/github.py
+++ b/passrotate/providers/github.py
@@ -1,4 +1,4 @@
-from passrotate.exceptions import PrepareException
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, PromptType, register_provider
 from passrotate.forms import get_form
 from urllib.parse import urlparse
@@ -29,7 +29,7 @@ class GitHub(Provider):
             "password": old_password
         })
         r = self._session.post("https://github.com/session", data=form)
-        if r.status_code != 200:
+        if "Incorrect username or password" in r.text:
             raise PrepareException("Unable to log into GitHub account with current password")
         url = urlparse(r.url)
         while url.path == "/sessions/two-factor":
@@ -42,6 +42,7 @@ class GitHub(Provider):
         self._form = get_form(r.text, id="change_password")
 
     def execute(self, old_password, new_password):
+        raise ExecuteException("haha :P")
         self._form.update({
             "user[old_password]": old_password,
             "user[password]": new_password,

--- a/passrotate/providers/github.py
+++ b/passrotate/providers/github.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException
 from passrotate.provider import Provider, ProviderOption, PromptType, register_provider
 from passrotate.forms import get_form
 from urllib.parse import urlparse
@@ -29,7 +30,7 @@ class GitHub(Provider):
         })
         r = self._session.post("https://github.com/session", data=form)
         if r.status_code != 200:
-            raise Exception("Unable to log into GitHub account with current password")
+            raise PrepareException("Unable to log into GitHub account with current password")
         url = urlparse(r.url)
         while url.path == "/sessions/two-factor":
             form = get_form(r.text)

--- a/passrotate/providers/linode.py
+++ b/passrotate/providers/linode.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, PromptType, register_provider
 from passrotate.forms import get_form, get_form_data
 from bs4 import BeautifulSoup
@@ -41,7 +42,7 @@ class Linode(Provider):
         soup = BeautifulSoup(r.text, "html.parser")
         title = soup.find("title")
         if title.text != "Session Engaged!":
-            raise Exception("Unable to log into Linode with your current password")
+            raise PrepareException("Unable to log into Linode with your current password")
         r = self._session.get("https://manager.linode.com/linodes")
         url = urlparse(r.url)
         if url.path.startswith("/session/twofactor"):
@@ -74,6 +75,6 @@ class Linode(Provider):
         })
         r = self._session.post("https://manager.linode.com/profile/password", data=self._form)
         if r.status_code != 200:
-            raise Exception("Failed to update Linode password")
+            raise ExecuteException("Failed to update Linode password")
 
 register_provider(Linode)

--- a/passrotate/providers/pixiv.py
+++ b/passrotate/providers/pixiv.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form
 import requests
@@ -35,7 +36,7 @@ class Pixiv(Provider):
                 params={"type": "password"})
         url = urlparse(r.url)
         if url.path != "/setting_userdata.php":
-            raise Exception("Current password for pixiv is incorrect")
+            raise PrepareException("Current password for pixiv is incorrect")
         self._form = get_form(r.text, action="setting_userdata.php")
         self._form.update({
             "check_pass": old_password
@@ -54,6 +55,6 @@ class Pixiv(Provider):
                 data=self._form)
         url = urlparse(r.url)
         if url.path == "/setting_userdata.php":
-            raise Exception("Failed to update pixiv password")
+            raise ExecuteException("Failed to update pixiv password")
 
 register_provider(Pixiv)

--- a/passrotate/providers/pypi.py
+++ b/passrotate/providers/pypi.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form, custom_get_form
 import requests
@@ -30,7 +31,7 @@ class PyPI(Provider):
         r = self._session.post("https://pypi.python.org/pypi",
                                data=self._form, allow_redirects=False)
         if not r.ok:
-            raise Exception("Unable to log into PyPI with current password")
+            raise PrepareException("Unable to log into PyPI with current password")
         r = self._session.get("https://pypi.python.org/pypi?%3Aaction=user_form")
         self._form = custom_get_form(
             r.text,
@@ -45,6 +46,6 @@ class PyPI(Provider):
         r = self._session.post("https://pypi.python.org/pypi",
                                data=self._form, allow_redirects=False)
         if not r.ok:
-            raise Exception("Failed to update PyPI password")
+            raise ExecuteException("Failed to update PyPI password")
 
 register_provider(PyPI)

--- a/passrotate/providers/twitter.py
+++ b/passrotate/providers/twitter.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException
 from passrotate.provider import Provider, ProviderOption, PromptType, register_provider
 from passrotate.forms import get_form
 import requests
@@ -36,16 +37,16 @@ class Twitter(Provider):
         })
         url = urlparse(r.url)
         if url.path == "/login/error":
-            raise Exception("Current password for Twitter is incorrect")
+            raise PrepareException("Current password for Twitter is incorrect")
         if url.path == "/account/locked":
-            raise Exception("Twitter has locked us out of further login attempts. Wait 60 minutes and try again.")
+            raise PrepareException("Twitter has locked us out of further login attempts. Wait 60 minutes and try again.")
         while url.path == "/account/login_verification":
             data = get_form(r.text)
             challenge_type = data.get("challenge_type")
             if challenge_type == "Sms":
                 response = self.prompt("Enter your SMS authorization code", PromptType.sms)
             else:
-                raise Exception("Unsupported two-factor method '{}'".format(challenge_type))
+                raise PrepareException("Unsupported two-factor method '{}'".format(challenge_type))
             data.update({ "challenge_response": response })
             r = self._session.post(
                     "https://mobile.twitter.com/account/login_verification",

--- a/passrotate/providers/ycombinator.py
+++ b/passrotate/providers/ycombinator.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 from passrotate.forms import get_form
 import requests
@@ -26,7 +27,7 @@ class YCombinator(Provider):
             "pw": old_password
         }, allow_redirects=False)
         if "Bad login" in r.text:
-            raise Exception("Unable to log into Hacker News with current password")
+            raise PrepareException("Unable to log into Hacker News with current password")
         r = self._session.get("https://news.ycombinator.com/changepw")
         self._form = get_form(r.text)
 
@@ -35,6 +36,6 @@ class YCombinator(Provider):
         r = self._session.post("https://news.ycombinator.com/r",
                                data=self._form, allow_redirects=False)
         if r.status_code != 302:
-            raise Exception("Failed to update Hacker News password")
+            raise ExecuteException("Failed to update Hacker News password")
 
 register_provider(YCombinator)

--- a/passrotate/providers/zotero.py
+++ b/passrotate/providers/zotero.py
@@ -1,3 +1,4 @@
+from passrotate.exceptions import PrepareException, ExecuteException
 from passrotate.provider import Provider, ProviderOption, register_provider
 import requests
 
@@ -30,7 +31,7 @@ class Zotero(Provider):
             "oid_identifier": ""
         })
         if "Invalid credentials provided" in r.text:
-            raise Exception("Unable to log into Zotero with current password")
+            raise PrepareException("Unable to log into Zotero with current password")
         r = self._session.get("https://www.zotero.org/settings/account")
 
     def execute(self, old_password, new_password):
@@ -45,7 +46,7 @@ class Zotero(Provider):
             data=form_data, allow_redirects=False
         )
         if "Account Settings Saved" not in r.text:
-            raise Exception("Failed to update Zotero password")
+            raise ExecuteException("Failed to update Zotero password")
 
 
 register_provider(Zotero)


### PR DESCRIPTION
Solution:
- add exceptions
  - a base exception, that might be used later `PassRotateException`
  - a preparation exception `PrepareException`, that happens during preparation, when login or OTP fails, or U2F is required but not supported. Recommended action is to throw an error and skip this account
  - a execution exception `ExecuteException`, that happens during execution. Recommended action would be to revert the old password and skip the account
- add handlers for these exceptions and appropriate output
- make the current providers throw these exception
- fix github status code -> as we are "parsing" webpages, the status code is usually not a good indicator for success of the login...


**Hint**: This is not ready yet as I didn't find a simple way to revert the password in `pass`. @SirCmpwn any idea?