### PR TITLE
Add GNU Social provider

### DIFF
--- a/passrotate/providers/__init__.py
+++ b/passrotate/providers/__init__.py
@@ -15,3 +15,4 @@ from passrotate.providers.ankiweb import AnkiWeb
 from passrotate.providers.gitlab import GitLab
 from passrotate.providers.wikipedia import Wikipedia
 from passrotate.providers.aur import ArchUserRepository
+from passrotate.providers.gnusocial import GNUSocial

--- a/passrotate/providers/gnusocial.py
+++ b/passrotate/providers/gnusocial.py
@@ -1,0 +1,49 @@
+from passrotate.provider import Provider, ProviderOption, register_provider
+from passrotate.forms import get_form
+import requests
+
+class GNUSocial(Provider):
+    """
+    username=Your GNU Social username
+    base_url=The base URL of your GNU Social instance
+    """
+    name = "GNU Social"
+    domains = []
+    options = {
+        "username": ProviderOption(str, "Your GNU Social username"),
+        "base_url": ProviderOption(str, "The base URL of your GNU Social instance")
+    }
+
+    def __init__(self, options):
+        self.username = options["username"]
+        self.base_url = options["base_url"]
+        self._login_url = self.base_url + "/main/login"
+        self._password_change_url = self.base_url + "/settings/password"
+
+    def _login(self, old_password):
+        r = self._session.get(self._login_url)
+        form = get_form(r.text, id="form_login")
+        form.update({
+            "nickname": self.username,
+            "password": old_password
+        })
+        r = self._session.post(self._login_url, data=form)
+        if r.status_code != 200:
+            raise Exception("Unable to log into your GNU Social account with current password")
+        return r
+
+    def prepare(self, old_password):
+        self._session = requests.Session()
+        self._login(old_password)
+        r = self._session.get(self._password_change_url)
+        self._form = get_form(r.text, id="form_password")
+
+    def execute(self, old_password, new_password):
+        self._form.update({
+            "oldpassword": old_password,
+            "newpassword": new_password,
+            "confirm": new_password
+        })
+        r = self._session.post(self._password_change_url, data=self._form)
+
+register_provider(GNUSocial)


### PR DESCRIPTION
This adds a provider for GNU Social.

I have made the `domains` member variable an empty list. This does have the undesirable side-effect that `pass-rotate --list-providers` does not list the GNU Social provider. I think the solution is to fix the behavior of `--list-providers`.

In addition to the usual `username` provider option, the GNU Social provider requires a `base_url` provider option. This option must be the base URL of the GNU Social instance of the account. Typically this is just a scheme and a top level domain like `https://social.example.com`, but there could be instances that are hosted under a specific path like `https://example.com/social`.